### PR TITLE
removing the "example genomes" menu

### DIFF
--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -84,3 +84,6 @@ include += {dataRoot}/functions.conf
 ## edit the datasets list below to add datasets to the jbrowse dataset
 ## selector
 
+[datasets.S.cerevisiae]
+name   = S. cerevisiae
+#url    = ?data=data/c_angaria_PRJNA51225

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -47,7 +47,7 @@ title = <i>Saccharomyces cerevisiae</i>
 # documentDomain=foobar.com
 
 ## use classic jbrowse menu with file instead of track and genome
-#classicMenu = true
+classicMenu = true
 
 ## hide open genome option
 #hideGenomeOptions = true

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -84,6 +84,6 @@ include += {dataRoot}/functions.conf
 ## edit the datasets list below to add datasets to the jbrowse dataset
 ## selector
 
-[datasets.S.cerevisiae]
+[datasets.yeast]
 name   = S. cerevisiae
 url    = ?data=data/

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -84,6 +84,6 @@ include += {dataRoot}/functions.conf
 ## edit the datasets list below to add datasets to the jbrowse dataset
 ## selector
 
-[datasets.yeast]
-name   = S. cerevisiae
-url    = ?data=data/
+#[datasets.yeast]
+#name   = S. cerevisiae
+#url    = ?data=data/

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -86,4 +86,4 @@ include += {dataRoot}/functions.conf
 
 [datasets.S.cerevisiae]
 name   = S. cerevisiae
-#url    = ?data=data/c_angaria_PRJNA51225
+url    = ?data=data

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -84,6 +84,6 @@ include += {dataRoot}/functions.conf
 ## edit the datasets list below to add datasets to the jbrowse dataset
 ## selector
 
-#[datasets.yeast]
-#name   = S. cerevisiae
-#url    = ?data=data/
+[datasets.yeast]
+name   = S. cerevisiae
+url    = ?data=data/

--- a/jbrowse.conf
+++ b/jbrowse.conf
@@ -86,4 +86,4 @@ include += {dataRoot}/functions.conf
 
 [datasets.S.cerevisiae]
 name   = S. cerevisiae
-url    = ?data=data
+url    = ?data=data/


### PR DESCRIPTION
This is the best solution I could come up with--the "example" genomes are hard coded into the JB code; to remove them, we have provide a "real" dataset and (oddly to me anyway) I also had to turn on the classic menu (which replaces "Genomes" in the upper left with the name of the first (and in this case, only) genome (which I honestly like better anyway).